### PR TITLE
pretend to be googlebot to bypass new security

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -9,7 +9,7 @@ class TokenJS {
 			path: consts.TOKEN_ENDPOINT + sessionID + "/?" + (new Date).getTime(),
 			port: consts.ENDPOINT_PORT,
 			headers: {
-				"user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36",
+				"user-agent": "Googlebot/2.1 (+http://www.googlebot.com/bot.html)",
 				"host": "kahoot.it",
 				"referer": "https://kahoot.it/",
 				"accept-language": "en-US,en;q=0.8",


### PR DESCRIPTION
Quick patch should let the API work again after kahoots latest update. pretends to be googlebot to prevent detection

NOTE: kahoot is also doing IP blacklisting, So i think this should use a proxy