### PR TITLE
Format and lint code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+charset = utf-8

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
 		"no-unused-vars": ["error", {"args": "none"}],
 		"no-empty": "off",
 		"no-control-regex": "off",
-		"indent": ["error", "tab"]
+		"indent": ["error", "tab"],
+		"quotes": ["error", "double", {"avoidEscape": true}]
 	},
 	"overrides": [
 		{

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+	"extends": "eslint:recommended",
+	"env": {
+		"node": true,
+		"commonjs": true,
+		"es6": true
+	},
+	"parserOptions": {
+		"sourceType": "module"
+	},
+	"rules": {
+		"semi": ["error", "always"],
+		"no-constant-condition": ["error", {"checkLoops": false}],
+		"no-unused-vars": ["error", {"args": "none"}],
+		"no-empty": "off",
+		"no-control-regex": "off",
+		"indent": ["error", "tab"]
+	},
+	"overrides": [
+		{
+			"files": ["main.js"],
+			"env": {
+				"node": true
+			}
+		}
+	]
+}

--- a/examples/advancedUsage.js
+++ b/examples/advancedUsage.js
@@ -4,14 +4,14 @@ console.log("Joining kahoot...");
 k.join(7877502 /* Or any other kahoot token */, "kahoot.js").then(() => {
 	console.log("joined quiz");
 	k.on("quizStart", quiz => {
-    	console.log("quiz "" + quiz.name + "" has started");
+		console.log("quiz " + quiz.name + " has started");
 	});
 	k.on("question", question => {
 		console.log("Recieved a new question. waiting until it starts..");
 	});
 	k.on("questionStart", question => {
-	    console.log("question started. answering answer id 1 (answer 2)");
-	    question.answer(1);
+		console.log("question started. answering answer id 1 (answer 2)");
+		question.answer(1);
 	});
 	k.on("questionSubmit", event => {
 		console.log("Submitted the answer. Kahoot says", event.message);
@@ -28,6 +28,6 @@ k.join(7877502 /* Or any other kahoot token */, "kahoot.js").then(() => {
 		console.log("the quiz is finishing, Kahoot says", e.firstMessage);
 	});
 	k.on("quizEnd", () => {
-	    console.log("the quiz ended");
+		console.log("the quiz ended");
 	});
 });

--- a/examples/basicUsage.js
+++ b/examples/basicUsage.js
@@ -3,15 +3,15 @@ var client = new Kahoot;
 console.log("Joining kahoot...");
 client.join(9802345 /* Or any other kahoot token */, "kahoot.js");
 client.on("joined", () => {
-    console.log("I joined the Kahoot!");
+	console.log("I joined the Kahoot!");
 });
 client.on("quizStart", quiz => {
-    console.log("The quiz has started! The quiz's name is:", quiz.name);
+	console.log("The quiz has started! The quiz's name is:", quiz.name);
 });
 client.on("questionStart", question => {
-    console.log("A new question has started, answering the first answer.");
-    question.answer(0);
+	console.log("A new question has started, answering the first answer.");
+	question.answer(0);
 });
 client.on("quizEnd", () => {
-    console.log("The quiz has ended.");
+	console.log("The quiz has ended.");
 });

--- a/examples/nemisis.js
+++ b/examples/nemisis.js
@@ -3,21 +3,21 @@ var k = new Kahoot;
 console.log("Joining kahoot...");
 k.join(9802345 /* Or any other kahoot token */, "kahoot.js").then(() => {
 	k.on("quizStart", quiz => {
-    	console.log("the quiz started with name", quiz.name);
+		console.log("the quiz started with name", quiz.name);
 	});
 	k.on("questionStart", question => {
-	    console.log("A new question has started, answering the first answer.");
-	    question.answer(0);
+		console.log("A new question has started, answering the first answer.");
+		question.answer(0);
 	});
 	k.on("questionEnd", event => {
 		console.log("the question ended.");
 		if (k.nemesis && k.nemesis.exists) {
-			console.log("i have a nemesis with name", nemesis.name);
+			console.log("i have a nemesis with name", k.nemesis.name);
 		} else {
 			console.log("i dont have a nemesis.");
 		}
 	});
 	k.on("quizEnd", () => {
-	    console.log("the quiz ended");
+		console.log("the quiz ended");
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,34 +4,731 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.8.3"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "acorn": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+      "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
-    "docopt": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
-      "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE="
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
-    "dot-json": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dot-json/-/dot-json-1.1.0.tgz",
-      "integrity": "sha512-PiQZW9/C8xILPYK2bOye/cbPZrakNEkt28jFb8RlPCwsoMAHYYw9T8JoACxgttHL9Y2AmdqVvibbZJHtLgeqTQ==",
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
-        "docopt": "~0.6.2",
-        "underscore-keypath": "~0.0.22"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+      "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
+      "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
+      "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "promise": {
       "version": "8.0.3",
@@ -41,26 +738,295 @@
         "asap": "~2.0.6"
       }
     },
-    "underscore": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
-    "underscore-keypath": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/underscore-keypath/-/underscore-keypath-0.0.22.tgz",
-      "integrity": "sha1-SKUoOSu278QkvhyqVtpLX6zPJk0=",
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
       "requires": {
-        "underscore": "*"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       }
     },
-    "user-agents": {
-      "version": "1.0.496",
-      "resolved": "https://registry.npmjs.org/user-agents/-/user-agents-1.0.496.tgz",
-      "integrity": "sha512-nZfYOtgWuOzvnCjfG6JCgVAGrV9yfrh/2DpRILBD4oJnzl5/iQzHfV7y109LSp7Edz7gyeU3UrYwPvwYAP5h5g==",
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "requires": {
-        "dot-json": "^1.1.0",
-        "lodash.clonedeep": "^4.5.0"
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
       }
     },
     "ws": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   },
   "bugs": {
     "url": "https://github.com/theusaf/kahoot.js-updated/issues"
+  },
+  "devDependencies": {
+    "eslint": "^6.8.0"
   }
 }

--- a/src/Assets.js
+++ b/src/Assets.js
@@ -18,7 +18,7 @@ class Question {
 		this.quiz = client.quiz;
 		this.index = rawEvent.questionIndex;
 		this.timeLeft = rawEvent.timeLeft;
-		this.type = rawEvent.type,
+		this.type = rawEvent.type;
 		this.usesStoryBlocks = rawEvent.useStoryBlocks;
 		this.ended = false;
 		this.quiz.questions.push(this);
@@ -31,7 +31,7 @@ class Question {
 			else {
 				this.client.answerQuestion(number).then(() => {
 					fulfill();
-				}).catch(e=>{
+				}).catch(e => {
 					reject();
 					console.log(e);
 				});
@@ -41,7 +41,7 @@ class Question {
 }
 class QuestionEndEvent {
 	constructor(rawEvent, client) {
-		try{
+		try {
 			this.client = client;
 			this.quiz = client.quiz;
 			this.question = this.quiz.questions[this.quiz.questions.length - 1];
@@ -56,7 +56,7 @@ class QuestionEndEvent {
 			this.points = rawEvent.points;
 			this.rank = rawEvent.rank;
 			this.total = rawEvent.totalScore;
-		}catch(e){
+		} catch (e) {
 			console.log("GET_END_EVT_ERR"); //this error will usually only happen if you join during the game.
 		}
 	}

--- a/src/Assets.js
+++ b/src/Assets.js
@@ -31,7 +31,10 @@ class Question {
 			else {
 				this.client.answerQuestion(number).then(() => {
 					fulfill();
-				}).catch(e=>{reject(),console.log(e)});
+				}).catch(e=>{
+					reject();
+					console.log(e);
+				});
 			}
 		});
 	}
@@ -113,4 +116,4 @@ module.exports = {
 	Nemesis: Nemesis,
 	FinishTextEvent: FinishTextEvent,
 	QuizFinishEvent: QuizFinishEvent
-}
+};

--- a/src/WSHandler.js
+++ b/src/WSHandler.js
@@ -6,7 +6,6 @@ var consts = require("./consts.js");
 class WSHandler extends EventEmitter {
 	constructor(session, token, kahoot) {
 		super();
-		var me = this;
 		this.requires2Step = false;
 		this.finished2Step = false;
 		this.kahoot = kahoot;
@@ -22,32 +21,32 @@ class WSHandler extends EventEmitter {
 		});
 		// Create anonymous callbacks to prevent an event emitter loop
 		this.ws.on("open", () => {
-			me.open();
+			this.open();
 		});
 		this.ws.on("message", msg => {
-			me.message(msg);
+			this.message(msg);
 		});
 		this.ws.on("close", () => {
-			me.connected = false;
-			me.close();
+			this.connected = false;
+			this.close();
 		});
 		this.dataHandler = {
 			1: (data, content) => {
 				try{
 					//if joining during the quiz
-					if(!me.kahoot.quiz){
-						me.emit("quizData",{name: null, type: content.quizType, qCount: content.quizQuestionAnswers[0], totalQ: content.quizQuestionAnswers.length, quizQuestionAnswers: content.quizQuestionAnswers});
+					if(!this.kahoot.quiz){
+						this.emit("quizData",{name: null, type: content.quizType, qCount: content.quizQuestionAnswers[0], totalQ: content.quizQuestionAnswers.length, quizQuestionAnswers: content.quizQuestionAnswers});
 					}
-					if (!me.kahoot.quiz.currentQuestion) {
-						me.emit("quizUpdate", {
+					if (!this.kahoot.quiz.currentQuestion) {
+						this.emit("quizUpdate", {
 							questionIndex: content.questionIndex,
 							timeLeft: content.timeLeft,
 							type: content.gameBlockType,
 							useStoryBlocks: content.canAccessStoryBlocks,
 							ansMap: content.answerMap
 						});
-					} else if (content.questionIndex > me.kahoot.quiz.currentQuestion.index) {
-						me.emit("quizUpdate", {
+					} else if (content.questionIndex > this.kahoot.quiz.currentQuestion.index) {
+						this.emit("quizUpdate", {
 							questionIndex: content.questionIndex,
 							timeLeft: content.timeLeft,
 							type: content.gameBlockType,
@@ -60,10 +59,10 @@ class WSHandler extends EventEmitter {
 				}
 			},
 			2: (data, content) => {
-				me.emit("questionStart");
+				this.emit("questionStart");
 			},
 			3: (data, content) => {
-				me.emit("finish", {
+				this.emit("finish", {
 					playerCount: content.playerCount,
 					quizID: content.quizId,
 					rank: content.rank,
@@ -72,11 +71,11 @@ class WSHandler extends EventEmitter {
 				});
 			},
 			7: (data, content) => { // Appears to be removed in V2
-				me.emit("questionSubmit", content.primaryMessage);
+				this.emit("questionSubmit", content.primaryMessage);
 			},
 			8: (data, content) => {
 				// console.log(data);
-				me.emit("questionEnd", {
+				this.emit("questionEnd", {
 					correctAnswers: content.correctAnswers,
 					correct: content.isCorrect,
 					points: content.points,
@@ -89,9 +88,9 @@ class WSHandler extends EventEmitter {
 				});
 			},
 			9: (data, content) => {
-				if (!me.firstQuizEvent) {
-					me.firstQuizEvent = true;
-					me.emit("quizData", {
+				if (!this.firstQuizEvent) {
+					this.firstQuizEvent = true;
+					this.emit("quizData", {
 						name: content.quizName,
 						type: content.quizType,
 						qCount: content.quizQuestionAnswers[0],
@@ -102,22 +101,22 @@ class WSHandler extends EventEmitter {
 			},
 			10: (data, content) => {
 				// The quiz has ended
-				me.emit("quizEnd");
+				this.emit("quizEnd");
 				try {
-					me.ws.close();
+					this.ws.close();
 				} catch (e) {
 					// Most likely already closed
 				}
 			},
 			13: (data, content) => {
-				me.emit("finishText", {
+				this.emit("finishText", {
 					metal: content.podiumMedalType,
 					msg1: content.primaryMessage,
 					msg2: content.secondaryMessage
 				});
 			},
 			12: (data, content)=>{
-				me.emit("feedback");
+				this.emit("feedback");
 			}
 		};
 	}
@@ -132,27 +131,26 @@ class WSHandler extends EventEmitter {
 		};
 	}
 	getPacket(packet) {
-		var me = this;
 		var l,o;
 		try{
 			l = Math.round(((new Date).getTime() - packet.ext.timesync.tc - packet.ext.timesync.p) / 2);
 			o = (packet.ext.timesync.ts - packet.ext.timesync.tc - l);
-			me.timesync = {
+			this.timesync = {
 				tc: (new Date).getTime(),
 				l: l,
 				o: o
 			};
 		}catch(err){
-			me.timesync = {
+			this.timesync = {
 				tc: (new Date).getTime(),
 				l: 0,
 				o: 0
 			};
 		}
-		me.msgID++;
+		this.msgID++;
 		return [{
 			channel: packet.channel,
-			clientId: me.clientID,
+			clientId: this.clientID,
 			ext: {
 				ack: packet.ext.ack,
 				timesync: {
@@ -161,35 +159,34 @@ class WSHandler extends EventEmitter {
 					tc: (new Date).getTime()
 				}
 			},
-			id: me.msgID + ""
+			id: this.msgID + ""
 		}];
 	}
 	getSubmitPacket(questionChoice) {
-		var me = this;
-		me.msgID++;
+		this.msgID++;
 		const r = [{
 			channel: "/service/controller",
-			clientId: me.clientID,
+			clientId: this.clientID,
 			data: {
 				content: JSON.stringify({
 					choice: questionChoice,
-					questionIndex: me.kahoot.quiz.currentQuestion.index,
+					questionIndex: this.kahoot.quiz.currentQuestion.index,
 					meta: {
 						lag: 30
 					}
 				}),
-				gameid: me.gameID,
+				gameid: this.gameID,
 				host: consts.ENDPOINT_URI,
 				id: 45,
 				type: "message"
 			},
-			id: me.msgID + ""
+			id: this.msgID + ""
 		}];
 		// for question type "open_ended," expect a string.
 		if(typeof(questionChoice) == "string"){
 			r[0].data.content = JSON.stringify({
 				text: questionChoice,
-				questionIndex: me.kahoot.quiz.currentQuestion.index,
+				questionIndex: this.kahoot.quiz.currentQuestion.index,
 				meta: {
 					lag: 30
 				}
@@ -208,15 +205,13 @@ class WSHandler extends EventEmitter {
 		});
 	}
 	sendSubmit(questionChoice) {
-		var me = this;
 		var packet = this.getSubmitPacket(questionChoice);
 		this.send(packet).then(()=>{
 			const snark = ["Toooo fast?","Genius machine?","Pure luck or true genius?"];
-			me.emit("questionSubmit",snark[Math.floor(Math.random()*snark.length)]);
+			this.emit("questionSubmit",snark[Math.floor(Math.random()*snark.length)]);
 		});
 	}
 	open() {
-		var me = this;
 		this.connected = true;
 		this.emit("open");
 		var r = [{
@@ -241,187 +236,182 @@ class WSHandler extends EventEmitter {
 				version: "1.0"
 			}
 		}];
-		me.msgID++;
-		me.send(r);
+		this.msgID++;
+		this.send(r);
 	}
 	message(msg) {
 		//console.log("D " + msg);
-		var me = this;
 		var data = JSON.parse(msg)[0];
 		if (data.channel == consts.CHANNEL_HANDSHAKE && data.clientId) { // The server sent a handshake packet
 			this.clientID = data.clientId;
-			var r = me.getPacket(data)[0];
+			var r = this.getPacket(data)[0];
 			r.advice = {timeout: 0};
 			r.channel = "/meta/connect";
 			r.connectionType = "websocket";
 			r.ext.ack = 0;
-			me.send([r]);
+			this.send([r]);
 		} else if(data.channel == consts.CHANNEL_CONN && data.advice && data.advice.reconnect && data.advice.reconnect == "retry"){
 			//connect packet
 			var connectionPacket = {
 				ext: {
 					ack: 1,
-					timesync: me.timesync
+					timesync: this.timesync
 				},
-				id: ++me.msgID + ""
+				id: ++this.msgID + ""
 			};
 			connectionPacket.channel = consts.CHANNEL_CONN;
-			connectionPacket.clientId = me.clientID;
+			connectionPacket.clientId = this.clientID;
 			connectionPacket.connectionType = "websocket";
-			me.send(connectionPacket);
-			me.emit("ready");
-			me.ready = true;
+			this.send(connectionPacket);
+			this.emit("ready");
+			this.ready = true;
 		}else if (data.channel == consts.CHANNEL_SUBSCR) {
-			if (data.subscription == "/service/controller" && data.successful == true && !me.ready) {
-				me.emit("ready");
-				me.ready = true;
+			if (data.subscription == "/service/controller" && data.successful == true && !this.ready) {
+				this.emit("ready");
+				this.ready = true;
 			}
 		} else if (data.data) {
 			if (data.data.error) {
 				if(data.data.type && data.data.type == "loginResponse"){
-					return me.emit("invalidName");
+					return this.emit("invalidName");
 				}
 				try{
-					me.emit("error", data.data.error); //error here if stuff
+					this.emit("error", data.data.error); //error here if stuff
 				}catch(er){
 					//error. usually due to username taken
 				}
 				return;
 			} else if (data.data.type == "loginResponse") {
 				// "/service/controller"
-				me.kahoot.cid = data.data.cid;
-				me.emit("joined");
+				this.kahoot.cid = data.data.cid;
+				this.emit("joined");
 			} else {
 				if (data.data.content) {
 					var cont = JSON.parse(data.data.content);
-					if (me.dataHandler[data.data.id]) {
-						me.dataHandler[data.data.id](data, cont);
+					if (this.dataHandler[data.data.id]) {
+						this.dataHandler[data.data.id](data, cont);
 					} else {
 						// console.log(data);
 					}
 				}
 			}
 		}
-		if (data.ext && data.channel == "/meta/connect" && me.ready) {
-			var packet = me.getPacket(data)[0];
+		if (data.ext && data.channel == "/meta/connect" && this.ready) {
+			var packet = this.getPacket(data)[0];
 			packet.connectionType = "websocket";
-			me.send([packet]);
+			this.send([packet]);
 		}
 		/*if(data.channel == "/service/player"){
 			console.log(data.data);
 		}*/
-		if (!me.finished2Step && data.channel == "/service/player" && data.data) {
+		if (!this.finished2Step && data.channel == "/service/player" && data.data) {
 			if (data.data.id == 52) {
-				me.finished2Step = true;
+				this.finished2Step = true;
 			} else if (data.data.id == 53) {
-				me.requires2Step = true;
-				me.emit("2step");
+				this.requires2Step = true;
+				this.emit("2step");
 			}
 		}
 	}
 	send2Step(steps){
-		var me = this;
 		var packet = [{
 			channel: "/service/controller",
-			clientId: me.clientID,
+			clientId: this.clientID,
 			data: {
 				id: 50,
 				type: "message",
-				gameid: me.gameID,
+				gameid: this.gameID,
 				host: consts.ENDPOINT_URI,
 				content: JSON.stringify({
 					sequence: steps
 				})
 			},
-			id: me.msgID + ""
+			id: this.msgID + ""
 		}];
 		this.send(packet);
 	}
 	sendFeedback(fun,learning,recommend,overall){
-		var me = this;
 		var packet = [{
 			channel: "/service/controller",
-			clientId: me.clientID,
+			clientId: this.clientID,
 			data: {
 				id: 11,
 				type: "message",
-				gameid: me.gameID,
+				gameid: this.gameID,
 				host: consts.ENDPOINT_URI,
 				content: JSON.stringify({
-					totalScore: me.kahoot.totalScore,
+					totalScore: this.kahoot.totalScore,
 					fun: fun,
 					learning: learning,
 					recommend: recommend,
 					overall: overall,
-					nickname: me.kahoot.name
+					nickname: this.kahoot.name
 				})
 			},
-			id: me.msgID + ""
+			id: this.msgID + ""
 		}];
 		this.send(packet);
 	}
 	relog(cid){
-		var me = this;
-		if(!me.ready){
-			setTimeout(()=>{me.relog(cid);},500);
+		if(!this.ready){
+			setTimeout(()=>{this.relog(cid);},500);
 			return;
 		}
-		me.msgID++;
+		this.msgID++;
 		let packet = {
 			channel: "/service/controller",
-			clientId: me.clientID,
+			clientId: this.clientID,
 			data: {
 				cid: cid,
 				content: JSON.stringify({device:{userAgent:"kahoot.js",screen:{width:2000,height:1000}}}),
-				gameid: me.gameID,
+				gameid: this.gameID,
 				host: "kahoot.it",
 				type: "relogin"
 			},
 			ext: {},
-			id: me.msgID + ""
+			id: this.msgID + ""
 		};
-		me.send([packet]);
+		this.send([packet]);
 	}
 	login(name,team) {
-		var me = this;
-		if(!me.ready){
-			setTimeout(()=>{me.login(name);},500);
+		if(!this.ready){
+			setTimeout(()=>{this.login(name);},500);
 			return;
 		}
-		me.name = name;
+		this.name = name;
 		var joinPacket = [{
 			channel: "/service/controller",
-			clientId: me.clientID,
+			clientId: this.clientID,
 			data: {
 				content: '{"device":{"userAgent":"kahoot.js","screen":{"width":1280,"height":800}}}',
-				gameid: me.gameID,
+				gameid: this.gameID,
 				host: consts.ENDPOINT_URI,
-				name: me.name,
+				name: this.name,
 				type: "login"
 			},
 			ext: {},
 			participantUserId: null,
-			id: me.msgID + ""
+			id: this.msgID + ""
 		}];
-		me.msgID++;
+		this.msgID++;
 		this.send(joinPacket);
-		if(me.kahoot.gamemode == "team"){
+		if(this.kahoot.gamemode == "team"){
 			const joinPacket2 = [{
 				channel: "/service/controller",
-				clientId: me.clientID,
+				clientId: this.clientID,
 				data: {
 					content: JSON.stringify(team && typeof(team.push) == "function" && team.length ? team : ["Player 1","Player 2","Player 3","Player 4"]),
-					gameid: me.gameID,
+					gameid: this.gameID,
 					host: consts.ENDPOINT_URI,
 					id: 18,
 					type: "message"
 				},
 				ext: {},
 				participantUserId: null,
-				id: me.msgID + ""
+				id: this.msgID + ""
 			}];
-			me.msgID++;
-			me.send(joinPacket2);
+			this.msgID++;
+			this.send(joinPacket2);
 		}
 	}
 	close() {
@@ -429,18 +419,17 @@ class WSHandler extends EventEmitter {
 		this.emit("close");
 	}
 	leave(){
-		var me = this;
-		me.msgID++;
-		try{me.timesync.tc = Date.now();}catch(err){console.log(err);}
+		this.msgID++;
+		try{this.timesync.tc = Date.now();}catch(err){console.log(err);}
 		//console.log(me.timesync);
-		me.send([{
+		this.send([{
 			channel: "/meta/disconnect",
-			clientId: me.clientID,
+			clientId: this.clientID,
 			ext: {
-				timesync: me.timesync
+				timesync: this.timesync
 			},
-			id: me.msgID + ""
-		}]).then(setTimeout(()=>{me.ws.close();},500));
+			id: this.msgID + ""
+		}]).then(setTimeout(()=>{this.ws.close();},500));
 	}
 }
 module.exports = WSHandler;

--- a/src/WSHandler.js
+++ b/src/WSHandler.js
@@ -119,7 +119,7 @@ class WSHandler extends EventEmitter {
 			12: (data, content)=>{
 				me.emit("feedback");
 			}
-		}
+		};
 	}
 	getExt() {
 		return {
@@ -129,7 +129,7 @@ class WSHandler extends EventEmitter {
 				o: 0,
 				tc: (new Date).getTime()
 			}
-		}
+		};
 	}
 	getPacket(packet) {
 		var me = this;
@@ -147,7 +147,7 @@ class WSHandler extends EventEmitter {
 				tc: (new Date).getTime(),
 				l: 0,
 				o: 0
-			}
+			};
 		}
 		me.msgID++;
 		return [{

--- a/src/consts.js
+++ b/src/consts.js
@@ -20,4 +20,4 @@ module.exports = {
 		"websocket",
 		"long-polling"
 	]
-}
+};

--- a/src/consts.js
+++ b/src/consts.js
@@ -2,7 +2,7 @@ module.exports = {
 	ENDPOINT_URI: "kahoot.it",
 	ENDPOINT_PORT: 443,
 	TOKEN_ENDPOINT: "/reserve/session/",
-	EVAL_: "var _ = {" +
+	EVAL_:  "var _ = {" +
 			"	replace: function() {" +
 			"		var args = arguments;" +
 			"		var str = arguments[0];" +

--- a/src/kahoot.js
+++ b/src/kahoot.js
@@ -21,77 +21,75 @@ class Kahoot extends EventEmitter {
 		this.cid = "";
 	}
 	reconnect(){
-		var me = this;
-		if(me.sessionID && me.cid && me._wsHandler && me._wsHandler.ws.readyState >= 2){
-			token.resolve(me.sessionID, (resolvedToken,gamemode) => {
-				me.gamemode = gamemode ? gamemode : "classic";
-				me.token = resolvedToken;
-				me._wsHandler = new WSHandler(me.sessionID, me.token, me);
-				me._wsHandler.on("invalidName",()=>{
-					me.emit("invalidName");
+		if(this.sessionID && this.cid && this._wsHandler && this._wsHandler.ws.readyState >= 2){
+			token.resolve(this.sessionID, (resolvedToken,gamemode) => {
+				this.gamemode = gamemode ? gamemode : "classic";
+				this.token = resolvedToken;
+				this._wsHandler = new WSHandler(this.sessionID, this.token, this);
+				this._wsHandler.on("invalidName",()=>{
+					this.emit("invalidName");
 				});
-				me._wsHandler.on("2step",()=>{
-					me.emit("2Step");
+				this._wsHandler.on("2step",()=>{
+					this.emit("2Step");
 				});
-				me._wsHandler.on("ready", () => {
-					me._wsHandler.relog(me.cid);
+				this._wsHandler.on("ready", () => {
+					this._wsHandler.relog(this.cid);
 				});
-				me._wsHandler.on("joined", () => {
-					me.emit("ready");
-					me.emit("joined");
+				this._wsHandler.on("joined", () => {
+					this.emit("ready");
+					this.emit("joined");
 					//fulfill();
 				});
-				me._wsHandler.on("quizData", quizInfo => {
-					me.quiz = new Assets.Quiz(quizInfo.name, quizInfo.type, quizInfo.qCount, me, quizInfo.totalQ, quizInfo.quizQuestionAnswers);
-					me.emit("quizStart", me.quiz);
-					me.emit("quiz", me.quiz);
+				this._wsHandler.on("quizData", quizInfo => {
+					this.quiz = new Assets.Quiz(quizInfo.name, quizInfo.type, quizInfo.qCount, this, quizInfo.totalQ, quizInfo.quizQuestionAnswers);
+					this.emit("quizStart", this.quiz);
+					this.emit("quiz", this.quiz);
 				});
-				me._wsHandler.on("quizUpdate", updateInfo => {
-					me.quiz.currentQuestion = new Assets.Question(updateInfo, me);
-					me.emit("question", me.quiz.currentQuestion);
+				this._wsHandler.on("quizUpdate", updateInfo => {
+					this.quiz.currentQuestion = new Assets.Question(updateInfo, this);
+					this.emit("question", this.quiz.currentQuestion);
 				});
-				me._wsHandler.on("questionEnd", endInfo => {
-					var e = new Assets.QuestionEndEvent(endInfo, me);
-					me.totalScore = e.total;
-					me.emit("questionEnd", e);
+				this._wsHandler.on("questionEnd", endInfo => {
+					var e = new Assets.QuestionEndEvent(endInfo, this);
+					this.totalScore = e.total;
+					this.emit("questionEnd", e);
 				});
-				me._wsHandler.on("quizEnd", () => {
-					me.emit("quizEnd");
-					me.emit("disconnect");
+				this._wsHandler.on("quizEnd", () => {
+					this.emit("quizEnd");
+					this.emit("disconnect");
 				});
-				me._wsHandler.on("questionStart", () => {
+				this._wsHandler.on("questionStart", () => {
 					try{
-						me.emit("questionStart", me.quiz.currentQuestion);
+						this.emit("questionStart", this.quiz.currentQuestion);
 					}catch(e){
 						//joined during quiz (fixed v 1.1.1)
 					}
 				});
-				me._wsHandler.on("questionSubmit", message => {
-					me.sendingAnswer = false;
-					var e = new Assets.QuestionSubmitEvent(message, me);
-					me.emit("questionSubmit", e);
+				this._wsHandler.on("questionSubmit", message => {
+					this.sendingAnswer = false;
+					var e = new Assets.QuestionSubmitEvent(message, this);
+					this.emit("questionSubmit", e);
 					try {
-						me._qFulfill(e);
+						this._qFulfill(e);
 					} catch(e) { }
 				});
-				me._wsHandler.on("finishText", data => {
+				this._wsHandler.on("finishText", data => {
 					var e = new Assets.FinishTextEvent(data);
-					me.emit("finishText", e);
+					this.emit("finishText", e);
 				});
-				me._wsHandler.on("finish", data => {
-					var e = new Assets.QuizFinishEvent(data, me);
-					me.emit("finish", e);
+				this._wsHandler.on("finish", data => {
+					var e = new Assets.QuizFinishEvent(data, this);
+					this.emit("finish", e);
 				});
-				me._wsHandler.on("feedback", ()=>{
-					me.emit("feedback");
+				this._wsHandler.on("feedback", ()=>{
+					this.emit("feedback");
 				});
 			});
 		}
 	}
 	join(session, name, team) {
-		var me = this;
-		if(me._wsHandler && me._wsHandler.ready){
-			return me._wsHandler.login(name,team);
+		if(this._wsHandler && this._wsHandler.ready){
+			return this._wsHandler.login(name,team);
 		}
 		return new Promise((fulfill, reject) => {
 			if (!session) {
@@ -102,87 +100,85 @@ class Kahoot extends EventEmitter {
 				reject("You need a name to connect to a Kahoot!");
 				return;
 			}
-			me.sessionID = session;
-			me.name = name;
-			me.team = team;
+			this.sessionID = session;
+			this.name = name;
+			this.team = team;
 			token.resolve(session, (resolvedToken,gamemode) => {
-				me.gamemode = gamemode ? gamemode : "classic";
-				me.token = resolvedToken;
-				me._wsHandler = new WSHandler(me.sessionID, me.token, me);
-				me._wsHandler.on("invalidName",()=>{
-					me.emit("invalidName");
+				this.gamemode = gamemode ? gamemode : "classic";
+				this.token = resolvedToken;
+				this._wsHandler = new WSHandler(this.sessionID, this.token, this);
+				this._wsHandler.on("invalidName",()=>{
+					this.emit("invalidName");
 				});
-				me._wsHandler.on("2step",()=>{
-					me.emit("2Step");
+				this._wsHandler.on("2step",()=>{
+					this.emit("2Step");
 				});
-				me._wsHandler.on("ready", () => {
-					me._wsHandler.login(me.name,me.team);
+				this._wsHandler.on("ready", () => {
+					this._wsHandler.login(this.name,this.team);
 				});
-				me._wsHandler.on("joined", () => {
-					me.emit("ready");
-					me.emit("joined");
+				this._wsHandler.on("joined", () => {
+					this.emit("ready");
+					this.emit("joined");
 					fulfill();
 				});
-				me._wsHandler.on("quizData", quizInfo => {
-					me.quiz = new Assets.Quiz(quizInfo.name, quizInfo.type, quizInfo.qCount, me, quizInfo.totalQ, quizInfo.quizQuestionAnswers);
-					me.emit("quizStart", me.quiz);
-					me.emit("quiz", me.quiz);
+				this._wsHandler.on("quizData", quizInfo => {
+					this.quiz = new Assets.Quiz(quizInfo.name, quizInfo.type, quizInfo.qCount, this, quizInfo.totalQ, quizInfo.quizQuestionAnswers);
+					this.emit("quizStart", this.quiz);
+					this.emit("quiz", this.quiz);
 				});
-				me._wsHandler.on("quizUpdate", updateInfo => {
-					me.quiz.currentQuestion = new Assets.Question(updateInfo, me);
-					me.emit("question", me.quiz.currentQuestion);
+				this._wsHandler.on("quizUpdate", updateInfo => {
+					this.quiz.currentQuestion = new Assets.Question(updateInfo, this);
+					this.emit("question", this.quiz.currentQuestion);
 				});
-				me._wsHandler.on("questionEnd", endInfo => {
-					var e = new Assets.QuestionEndEvent(endInfo, me);
-					me.totalScore = e.total;
-					me.emit("questionEnd", e);
+				this._wsHandler.on("questionEnd", endInfo => {
+					var e = new Assets.QuestionEndEvent(endInfo, this);
+					this.totalScore = e.total;
+					this.emit("questionEnd", e);
 				});
-				me._wsHandler.on("quizEnd", () => {
-					me.emit("quizEnd");
-					me.emit("disconnect");
+				this._wsHandler.on("quizEnd", () => {
+					this.emit("quizEnd");
+					this.emit("disconnect");
 				});
-				me._wsHandler.on("questionStart", () => {
+				this._wsHandler.on("questionStart", () => {
 					try{
-						me.emit("questionStart", me.quiz.currentQuestion);
+						this.emit("questionStart", this.quiz.currentQuestion);
 					}catch(e){
 						//joined during quiz (fixed v 1.1.1)
 					}
 				});
-				me._wsHandler.on("questionSubmit", message => {
-					me.sendingAnswer = false;
-					var e = new Assets.QuestionSubmitEvent(message, me);
-					me.emit("questionSubmit", e);
+				this._wsHandler.on("questionSubmit", message => {
+					this.sendingAnswer = false;
+					var e = new Assets.QuestionSubmitEvent(message, this);
+					this.emit("questionSubmit", e);
 					try {
-						me._qFulfill(e);
+						this._qFulfill(e);
 					} catch(e) { }
 				});
-				me._wsHandler.on("finishText", data => {
+				this._wsHandler.on("finishText", data => {
 					var e = new Assets.FinishTextEvent(data);
-					me.emit("finishText", e);
+					this.emit("finishText", e);
 				});
-				me._wsHandler.on("finish", data => {
-					var e = new Assets.QuizFinishEvent(data, me);
-					me.emit("finish", e);
+				this._wsHandler.on("finish", data => {
+					var e = new Assets.QuizFinishEvent(data, this);
+					this.emit("finish", e);
 				});
-				me._wsHandler.on("feedback", ()=>{
-					me.emit("feedback");
+				this._wsHandler.on("feedback", ()=>{
+					this.emit("feedback");
 				});
 			});
 		});
 	}
 	answer2Step(steps){
-		var me = this;
 		return new Promise((f,r)=>{
-			me._qFulfill = f;
-			me._wsHandler.send2Step(steps.join(""));
+			this._qFulfill = f;
+			this._wsHandler.send2Step(steps.join(""));
 		});
 	}
 	answerQuestion(id) {
-		var me = this;
 		return new Promise((fulfill, reject) => {
-			me._qFulfill = fulfill;
-			me.sendingAnswer = true;
-			me._wsHandler.sendSubmit(id);
+			this._qFulfill = fulfill;
+			this.sendingAnswer = true;
+			this._wsHandler.sendSubmit(id);
 		});
 	}
 	leave() {

--- a/src/kahoot.js
+++ b/src/kahoot.js
@@ -20,16 +20,16 @@ class Kahoot extends EventEmitter {
 		this.gamemode = null;
 		this.cid = "";
 	}
-	reconnect(){
-		if(this.sessionID && this.cid && this._wsHandler && this._wsHandler.ws.readyState >= 2){
-			token.resolve(this.sessionID, (resolvedToken,gamemode) => {
+	reconnect() {
+		if (this.sessionID && this.cid && this._wsHandler && this._wsHandler.ws.readyState >= 2) {
+			token.resolve(this.sessionID, (resolvedToken, gamemode) => {
 				this.gamemode = gamemode ? gamemode : "classic";
 				this.token = resolvedToken;
 				this._wsHandler = new WSHandler(this.sessionID, this.token, this);
-				this._wsHandler.on("invalidName",()=>{
+				this._wsHandler.on("invalidName", () => {
 					this.emit("invalidName");
 				});
-				this._wsHandler.on("2step",()=>{
+				this._wsHandler.on("2step", () => {
 					this.emit("2Step");
 				});
 				this._wsHandler.on("ready", () => {
@@ -59,9 +59,9 @@ class Kahoot extends EventEmitter {
 					this.emit("disconnect");
 				});
 				this._wsHandler.on("questionStart", () => {
-					try{
+					try {
 						this.emit("questionStart", this.quiz.currentQuestion);
-					}catch(e){
+					} catch (e) {
 						//joined during quiz (fixed v 1.1.1)
 					}
 				});
@@ -71,7 +71,7 @@ class Kahoot extends EventEmitter {
 					this.emit("questionSubmit", e);
 					try {
 						this._qFulfill(e);
-					} catch(e) { }
+					} catch (e) {}
 				});
 				this._wsHandler.on("finishText", data => {
 					var e = new Assets.FinishTextEvent(data);
@@ -81,15 +81,15 @@ class Kahoot extends EventEmitter {
 					var e = new Assets.QuizFinishEvent(data, this);
 					this.emit("finish", e);
 				});
-				this._wsHandler.on("feedback", ()=>{
+				this._wsHandler.on("feedback", () => {
 					this.emit("feedback");
 				});
 			});
 		}
 	}
 	join(session, name, team) {
-		if(this._wsHandler && this._wsHandler.ready){
-			return this._wsHandler.login(name,team);
+		if (this._wsHandler && this._wsHandler.ready) {
+			return this._wsHandler.login(name, team);
 		}
 		return new Promise((fulfill, reject) => {
 			if (!session) {
@@ -103,18 +103,18 @@ class Kahoot extends EventEmitter {
 			this.sessionID = session;
 			this.name = name;
 			this.team = team;
-			token.resolve(session, (resolvedToken,gamemode) => {
+			token.resolve(session, (resolvedToken, gamemode) => {
 				this.gamemode = gamemode ? gamemode : "classic";
 				this.token = resolvedToken;
 				this._wsHandler = new WSHandler(this.sessionID, this.token, this);
-				this._wsHandler.on("invalidName",()=>{
+				this._wsHandler.on("invalidName", () => {
 					this.emit("invalidName");
 				});
-				this._wsHandler.on("2step",()=>{
+				this._wsHandler.on("2step", () => {
 					this.emit("2Step");
 				});
 				this._wsHandler.on("ready", () => {
-					this._wsHandler.login(this.name,this.team);
+					this._wsHandler.login(this.name, this.team);
 				});
 				this._wsHandler.on("joined", () => {
 					this.emit("ready");
@@ -140,9 +140,9 @@ class Kahoot extends EventEmitter {
 					this.emit("disconnect");
 				});
 				this._wsHandler.on("questionStart", () => {
-					try{
+					try {
 						this.emit("questionStart", this.quiz.currentQuestion);
-					}catch(e){
+					} catch (e) {
 						//joined during quiz (fixed v 1.1.1)
 					}
 				});
@@ -152,7 +152,7 @@ class Kahoot extends EventEmitter {
 					this.emit("questionSubmit", e);
 					try {
 						this._qFulfill(e);
-					} catch(e) { }
+					} catch (e) {}
 				});
 				this._wsHandler.on("finishText", data => {
 					var e = new Assets.FinishTextEvent(data);
@@ -162,15 +162,15 @@ class Kahoot extends EventEmitter {
 					var e = new Assets.QuizFinishEvent(data, this);
 					this.emit("finish", e);
 				});
-				this._wsHandler.on("feedback", ()=>{
+				this._wsHandler.on("feedback", () => {
 					this.emit("feedback");
 				});
 			});
 		});
 	}
-	answer2Step(steps){
-		return new Promise((f,r)=>{
-			this._qFulfill = f;
+	answer2Step(steps) {
+		return new Promise((fulfill, reject) => {
+			this._qFulfill = fulfill;
 			this._wsHandler.send2Step(steps.join(""));
 		});
 	}
@@ -188,9 +188,9 @@ class Kahoot extends EventEmitter {
 		});
 	}
 	//content: "{"totalScore":0,"fun":5,"learning":1,"recommend":1,"overall":1,"nickname":"oof"}"
-	sendFeedback(fun,learning,recommend,overall){
-		return new Promise((f,r)=>{
-			this._wsHandler.sendFeedback(fun,learning,recommend,overall);
+	sendFeedback(fun, learning, recommend, overall) {
+		return new Promise((f, r) => {
+			this._wsHandler.sendFeedback(fun, learning, recommend, overall);
 		});
 	}
 }

--- a/src/kahoot.js
+++ b/src/kahoot.js
@@ -84,7 +84,7 @@ class Kahoot extends EventEmitter {
 				});
 				me._wsHandler.on("feedback", ()=>{
 					me.emit("feedback");
-				})
+				});
 			});
 		}
 	}
@@ -166,7 +166,7 @@ class Kahoot extends EventEmitter {
 				});
 				me._wsHandler.on("feedback", ()=>{
 					me.emit("feedback");
-				})
+				});
 			});
 		});
 	}

--- a/src/token.js
+++ b/src/token.js
@@ -83,8 +83,7 @@ class TokenJS {
 		return token;
 	}
 	static resolve(sessionID, callback) {
-		var me = this;
-		me.requestToken(sessionID, (headerToken, challenge, gamemode) => {
+		this.requestToken(sessionID, (headerToken, challenge, gamemode) => {
 			var token1 = this.decodeBase64(headerToken);
 			var token2 = this.solveChallenge(challenge);
 			var resolvedToken = this.concatTokens(token1, token2);

--- a/src/token.js
+++ b/src/token.js
@@ -21,7 +21,7 @@ class TokenJS {
 				// The first token is the session token, which is given as a header by the server encoded in base64
 				// Checking if the header is defined before continuing, basically checking if the room exists.
 				if (!res.headers["x-kahoot-session-token"]) {
-					return console.log("request error:", "Kahoot session header is undefined. (This normally means that the room no longer exists.)")
+					return console.log("request error:", "Kahoot session header is undefined. (This normally means that the room no longer exists.)");
 				}
 				var token1 = res.headers["x-kahoot-session-token"];
 				var body = chunk.toString("utf8");
@@ -34,7 +34,7 @@ class TokenJS {
 					return;
 				}
 				// The second token is given as a "challenge", which must be eval'd by the client to be decoded
-				var challenge = bodyObject.challenge;
+				challenge = bodyObject.challenge;
 				callback(token1, challenge, bodyObject.gameMode);
 			});
 		}).on("error", err => {
@@ -75,10 +75,10 @@ class TokenJS {
 	static concatTokens(headerToken, challengeToken) {
 		// Combine the session token and the challenge token together to get the string needed to connect to the websocket endpoint
 		for (var token = "", i = 0; i < headerToken.length; i++) {
-		    var char = headerToken.charCodeAt(i);
-		    var mod = challengeToken.charCodeAt(i % challengeToken.length);
-		    var decodedChar = char ^ mod;
-		    token += String.fromCharCode(decodedChar);
+			var char = headerToken.charCodeAt(i);
+			var mod = challengeToken.charCodeAt(i % challengeToken.length);
+			var decodedChar = char ^ mod;
+			token += String.fromCharCode(decodedChar);
 		}
 		return token;
 	}

--- a/src/token.js
+++ b/src/token.js
@@ -1,6 +1,6 @@
 var https = require("https");
 var consts = require("./consts");
-const ua = require('user-agents');
+const ua = require("user-agents");
 
 class TokenJS {
 	static requestToken(sessionID, callback) {
@@ -44,11 +44,11 @@ class TokenJS {
 	}
 	static solveChallenge(challenge) {
 		var solved = "";
-		challenge = challenge.replace(/(\u0009|\u2003)/mg,"");
-		challenge = challenge.replace(/this /mg,"this");
-		challenge = challenge.replace(/ *\. */mg,".");
-		challenge = challenge.replace(/ *\( */mg,"(");
-		challenge = challenge.replace(/ *\) */mg,")");
+		challenge = challenge.replace(/(\u0009|\u2003)/mg, "");
+		challenge = challenge.replace(/this /mg, "this");
+		challenge = challenge.replace(/ *\. */mg, ".");
+		challenge = challenge.replace(/ *\( */mg, "(");
+		challenge = challenge.replace(/ *\) */mg, ")");
 		// Prevent any logging from the challenge, by default it logs some debug info
 		challenge = challenge.replace("console.", "");
 		// Make a few if-statements always return true as the functions are currently missing
@@ -66,9 +66,9 @@ class TokenJS {
 	}
 	static decodeBase64(b64) {
 		// for the session token
-		try{
+		try {
 			return new Buffer(b64, "base64").toString("ascii");
-		}catch(e){
+		} catch (e) {
 			console.log("Error! (Most likely not a kahoot game)");
 		}
 	}


### PR DESCRIPTION
Because these changes touch a lot of code, I think it makes sense to bundle them together.

* Enable ESLint
  * In editors like Visual Studio Code, this will provide warnings when you do things like create unused variables.

* Remove `var me = this;` pattern
  * Resolves #21
  * This pattern is unnecessary since this codebase uses arrow functions, which don't bind their own `this`.

* Reformat code (mostly spacing)
  * This takes care of inconsistent spacing, making the code much easier to read.

* Add .editorconfig
  * This makes GitHub display tabs as 4 spaces wide, rather than 8 spaces as it does currently. This significantly helps readability.